### PR TITLE
 Fix problem creating benchmark directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9.5)
  
 project(Vesselness)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(APPLE)


### PR DESCRIPTION
 - Change C++ standard from 11 to 17
 - Create file hierarchy using std::filesystem
 - Change typing for all paths from std::string to std::filesystem::path

/!\ Tested on Ubuntu 20.04 LTS. No further regression tests were performed.
